### PR TITLE
ECO-001 Fix Http Verbs to reflect actual operation and rename misleading method name

### DIFF
--- a/src/main/java/com/ecore/roles/web/MembershipsApi.java
+++ b/src/main/java/com/ecore/roles/web/MembershipsApi.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface MembershipsApi {
 
-    ResponseEntity<MembershipDto> assignRoleToMembership(
+    ResponseEntity<MembershipDto> createMembershipWithAssignedRole(
             MembershipDto membership);
 
     ResponseEntity<List<MembershipDto>> getMemberships(

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -23,10 +23,10 @@ public class MembershipsRestController implements MembershipsApi {
     private final MembershipsService membershipsService;
 
     @Override
-    @PutMapping(
+    @PostMapping(
             consumes = {"application/json"},
             produces = {"application/json"})
-    public ResponseEntity<MembershipDto> assignRoleToMembership(
+    public ResponseEntity<MembershipDto> createMembershipWithAssignedRole(
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
         Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
         return ResponseEntity

--- a/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
+++ b/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
@@ -65,7 +65,7 @@ public class RestAssuredHelper {
         return sendRequest(givenNullableBody(MembershipDto.fromModel(membership))
                 .contentType(JSON)
                 .when()
-                .put("/v1/roles/memberships")
+                .post("/v1/roles/memberships")
                 .then());
     }
 


### PR DESCRIPTION
## Description
The method assignRoleToMembership was misleading. The method not only assigns
a role, it basically creates a new Membership with an assigned role

## Proposed Changes
Rename the method assignRoleToMembership to createMembershipWithAssignedRole.
This will show clearly that we are creating a membership and not only updating it with a Role