### PR TITLE
ECO-002 Fix endpoints status code responses

### DIFF
--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -30,7 +30,7 @@ public class MembershipsRestController implements MembershipsApi {
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
         Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
         return ResponseEntity
-                .status(200)
+                .status(201)
                 .body(fromModel(membership));
     }
 

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -29,7 +29,7 @@ public class RolesRestController implements RolesApi {
     public ResponseEntity<RoleDto> createRole(
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
-                .status(200)
+                .status(201)
                 .body(fromModel(rolesService.CreateRole(role.toModel())));
     }
 

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -141,7 +141,7 @@ public class MembershipsApiTests {
                 .statusCode(200)
                 .extract().as(MembershipDto[].class);
 
-        assertThat(actualMemberships.length).isEqualTo(1);
+        assertThat(actualMemberships).hasSize(1);
         assertThat(actualMemberships[0].getId()).isNotNull();
         assertThat(actualMemberships[0]).isEqualTo(MembershipDto.fromModel(expectedMembership));
     }
@@ -152,7 +152,7 @@ public class MembershipsApiTests {
                 .statusCode(200)
                 .extract().as(MembershipDto[].class);
 
-        assertThat(actualMemberships.length).isEqualTo(0);
+        assertThat(actualMemberships).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Description
Several endpoints were not returning a proper http status code on creation.
It is a best practice to return 201 on resource creation.

## Proposed Changes
- Change the http status code response for multiple endpoint on creation.
- Fix some minor NITs in the test. We should try to use existing methods when possible.