### PR TITLE
ECO-004 Refactor MembershipApi to apply rest API best practices

### DIFF
--- a/backend-challenge.postman_collection.json
+++ b/backend-challenge.postman_collection.json
@@ -110,7 +110,7 @@
 					"response": []
 				},
 				{
-					"name": "/roles/memberships",
+					"name": "/memberships",
 					"request": {
 						"method": "POST",
 						"header": [],
@@ -140,24 +140,12 @@
 					"response": []
 				},
 				{
-					"name": "/roles/memberships/search",
-					"protocolProfileBehavior": {
-						"disableBodyPruning": true
-					},
+					"name": "/memberships/role/{roleId}",
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
 						"url": {
-							"raw": "http://localhost:8080/v1/roles/memberships/search?roleId=1b3c333b-36e7-4b64-aa15-c22ed5908ce4",
+							"raw": "http://localhost:8080/v1/memberships/role/1b3c333b-36e7-4b64-aa15-c22ed5908ce4",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -165,15 +153,9 @@
 							"port": "8080",
 							"path": [
 								"v1",
-								"roles",
 								"memberships",
-								"search"
-							],
-							"query": [
-								{
-									"key": "roleId",
-									"value": "1b3c333b-36e7-4b64-aa15-c22ed5908ce4"
-								}
+								"role",
+								"1b3c333b-36e7-4b64-aa15-c22ed5908ce4"
 							]
 						}
 					},

--- a/src/main/java/com/ecore/roles/service/MembershipsService.java
+++ b/src/main/java/com/ecore/roles/service/MembershipsService.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface MembershipsService {
 
-    Membership assignRoleToMembership(Membership membership) throws ResourceNotFoundException;
+    Membership createMembership(Membership membership) throws ResourceNotFoundException;
 
     List<Membership> getMemberships(UUID roleId);
 }

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -34,7 +34,7 @@ public class MembershipsServiceImpl implements MembershipsService {
     }
 
     @Override
-    public Membership assignRoleToMembership(@NonNull Membership m) {
+    public Membership createMembership(@NonNull Membership m) {
 
         UUID roleId = ofNullable(m.getRole()).map(Role::getId)
                 .orElseThrow(() -> new InvalidArgumentException(Role.class));

--- a/src/main/java/com/ecore/roles/web/MembershipsApi.java
+++ b/src/main/java/com/ecore/roles/web/MembershipsApi.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 
 public interface MembershipsApi {
 
-    ResponseEntity<MembershipDto> createMembershipWithAssignedRole(
+    ResponseEntity<MembershipDto> createMembership(
             MembershipDto membership);
 
     ResponseEntity<List<MembershipDto>> getMemberships(

--- a/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/MembershipsRestController.java
@@ -18,7 +18,7 @@ import static com.ecore.roles.web.dto.MembershipDto.fromModel;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping(value = "/v1/roles/memberships")
+@RequestMapping(value = "/v1/memberships")
 public class MembershipsRestController implements MembershipsApi {
 
     private final MembershipsService membershipsService;
@@ -27,9 +27,9 @@ public class MembershipsRestController implements MembershipsApi {
     @PostMapping(
             consumes = {"application/json"},
             produces = {"application/json"})
-    public ResponseEntity<MembershipDto> createMembershipWithAssignedRole(
+    public ResponseEntity<MembershipDto> createMembership(
             @NotNull @Valid @RequestBody MembershipDto membershipDto) {
-        Membership membership = membershipsService.assignRoleToMembership(membershipDto.toModel());
+        Membership membership = membershipsService.createMembership(membershipDto.toModel());
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(fromModel(membership));
@@ -37,10 +37,10 @@ public class MembershipsRestController implements MembershipsApi {
 
     @Override
     @GetMapping(
-            path = "/search",
+            path = "/role/{roleId}",
             produces = {"application/json"})
     public ResponseEntity<List<MembershipDto>> getMemberships(
-            @RequestParam UUID roleId) {
+            @PathVariable UUID roleId) {
 
         List<Membership> memberships = membershipsService.getMemberships(roleId);
 

--- a/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
+++ b/src/test/java/com/ecore/roles/api/MembershipsApiTests.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.UUID;
+
 import static com.ecore.roles.utils.MockUtils.mockGetTeamById;
 import static com.ecore.roles.utils.RestAssuredHelper.createMembership;
 import static com.ecore.roles.utils.RestAssuredHelper.getMemberships;
@@ -154,12 +156,6 @@ class MembershipsApiTests {
                 .extract().as(MembershipDto[].class);
 
         assertThat(actualMemberships).isEmpty();
-    }
-
-    @Test
-    void shouldFailToGetAllMembershipsWhenRoleIdIsNull() {
-        getMemberships(null)
-                .validate(HttpStatus.BAD_REQUEST.value(), "Bad Request");
     }
 
     private MembershipDto createDefaultMembership() {

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -50,7 +50,7 @@ class MembershipsServiceTest {
                 .save(expectedMembership))
                         .thenReturn(expectedMembership);
 
-        Membership actualMembership = membershipsService.assignRoleToMembership(expectedMembership);
+        Membership actualMembership = membershipsService.createMembership(expectedMembership);
 
         assertNotNull(actualMembership);
         assertEquals(actualMembership, expectedMembership);
@@ -60,7 +60,7 @@ class MembershipsServiceTest {
     @Test
     public void shouldFailToCreateMembershipWhenMembershipsIsNull() {
         assertThrows(NullPointerException.class,
-                () -> membershipsService.assignRoleToMembership(null));
+                () -> membershipsService.createMembership(null));
     }
 
     @Test
@@ -71,7 +71,7 @@ class MembershipsServiceTest {
                         .thenReturn(Optional.of(expectedMembership));
 
         ResourceExistsException exception = assertThrows(ResourceExistsException.class,
-                () -> membershipsService.assignRoleToMembership(expectedMembership));
+                () -> membershipsService.createMembership(expectedMembership));
 
         assertEquals("Membership already exists", exception.getMessage());
         verify(roleRepository, times(0)).getById(any());
@@ -85,7 +85,7 @@ class MembershipsServiceTest {
         expectedMembership.setRole(null);
 
         InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
-                () -> membershipsService.assignRoleToMembership(expectedMembership));
+                () -> membershipsService.createMembership(expectedMembership));
 
         assertEquals("Invalid 'Role' object", exception.getMessage());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());

--- a/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
+++ b/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
@@ -65,15 +65,15 @@ public class RestAssuredHelper {
         return sendRequest(givenNullableBody(MembershipDto.fromModel(membership))
                 .contentType(JSON)
                 .when()
-                .post("/v1/roles/memberships")
+                .post("/v1/memberships")
                 .then());
     }
 
     public static EcoreValidatableResponse getMemberships(UUID roleId) {
         return sendRequest(given()
-                .queryParam("roleId", roleId)
+                .pathParam("roleId", roleId)
                 .when()
-                .get("/v1/roles/memberships/search")
+                .get("/v1/memberships/role/{roleId}")
                 .then());
     }
 


### PR DESCRIPTION
## Description
The membership API is not using several of the best practices for Rest API design

## Proposed Changes
* It is a best practice to use directly the name of the resource for its' endpoints. I.e /v1/roles/memberships is not a
  correct path for dealing with memberships even if they are part of roles
* Having url paths with verbs is not adequate since using nouns + the right http verb is always preferable. 
  I.e /v1/roles/memberships/search it is a bad practice
* It is a recommended practice to use path parameters for unique identifiers of specific resources and use
  query parameters only for pagination, sorting, filtering.
* Change the base url for the membership resource to: /v1/memberships/
* Changed the path of the get method to: /v1/memberships/role/{roleId}
* Update the tests to reflect above changes and remove one since it was not possible 
  to receive roleId as a query parameter anymore