### PR TITLE
ECO-005 rename methods with first letter on upper case

### DIFF
--- a/src/main/java/com/ecore/roles/service/RolesService.java
+++ b/src/main/java/com/ecore/roles/service/RolesService.java
@@ -7,10 +7,10 @@ import java.util.UUID;
 
 public interface RolesService {
 
-    Role CreateRole(Role role);
+    Role createRole(Role role);
 
-    Role GetRole(UUID id);
+    Role getRole(UUID id);
 
-    List<Role> GetRoles();
+    List<Role> getRoles();
 
 }

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -36,7 +36,7 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Role CreateRole(@NonNull Role r) {
+    public Role createRole(@NonNull Role r) {
         if (roleRepository.findByName(r.getName()).isPresent()) {
             throw new ResourceExistsException(Role.class);
         }
@@ -44,13 +44,13 @@ public class RolesServiceImpl implements RolesService {
     }
 
     @Override
-    public Role GetRole(@NonNull UUID rid) {
+    public Role getRole(@NonNull UUID rid) {
         return roleRepository.findById(rid)
                 .orElseThrow(() -> new ResourceNotFoundException(Role.class, rid));
     }
 
     @Override
-    public List<Role> GetRoles() {
+    public List<Role> getRoles() {
         return roleRepository.findAll();
     }
 

--- a/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
+++ b/src/main/java/com/ecore/roles/web/rest/RolesRestController.java
@@ -31,7 +31,7 @@ public class RolesRestController implements RolesApi {
             @Valid @RequestBody RoleDto role) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(fromModel(rolesService.CreateRole(role.toModel())));
+                .body(fromModel(rolesService.createRole(role.toModel())));
     }
 
     @Override
@@ -39,7 +39,7 @@ public class RolesRestController implements RolesApi {
             produces = {"application/json"})
     public ResponseEntity<List<RoleDto>> getRoles() {
 
-        List<Role> getRoles = rolesService.GetRoles();
+        List<Role> getRoles = rolesService.getRoles();
 
         List<RoleDto> roleDtoList = new ArrayList<>();
 
@@ -61,7 +61,7 @@ public class RolesRestController implements RolesApi {
             @PathVariable UUID roleId) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(fromModel(rolesService.GetRole(roleId)));
+                .body(fromModel(rolesService.getRole(roleId)));
     }
 
 }

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -41,7 +41,7 @@ class RolesServiceTest {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.save(developerRole)).thenReturn(developerRole);
 
-        Role role = rolesService.CreateRole(developerRole);
+        Role role = rolesService.createRole(developerRole);
 
         assertNotNull(role);
         assertEquals(developerRole, role);
@@ -50,7 +50,7 @@ class RolesServiceTest {
     @Test
     public void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
-                () -> rolesService.CreateRole(null));
+                () -> rolesService.createRole(null));
     }
 
     @Test
@@ -58,7 +58,7 @@ class RolesServiceTest {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
-        Role role = rolesService.GetRole(developerRole.getId());
+        Role role = rolesService.getRole(developerRole.getId());
 
         assertNotNull(role);
         assertEquals(developerRole, role);
@@ -67,7 +67,7 @@ class RolesServiceTest {
     @Test
     public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
-                () -> rolesService.GetRole(UUID_1));
+                () -> rolesService.getRole(UUID_1));
 
         assertEquals(format("Role %s not found", UUID_1), exception.getMessage());
     }


### PR DESCRIPTION

## Description
The RolesService interface was declaring all his methods with the first letter in upper case

## Proposed Changes
* Rename all the methods in the RolesService interface to use standard naming convention for methods.