### PR TITLE
ECO-007 Decouple RolesServiceImpl and MembershipServiceImpl

### DIFF
--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -8,8 +8,8 @@ import com.ecore.roles.exception.ResourceNotFoundException;
 import com.ecore.roles.model.Membership;
 import com.ecore.roles.model.Role;
 import com.ecore.roles.repository.MembershipRepository;
-import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.MembershipsService;
+import com.ecore.roles.service.RolesService;
 import com.ecore.roles.service.TeamsService;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
@@ -26,17 +26,17 @@ import static java.util.Optional.ofNullable;
 public class MembershipsServiceImpl implements MembershipsService {
 
     private final MembershipRepository membershipRepository;
-    private final RoleRepository roleRepository;
+    private final RolesService rolesService;
 
     private final TeamsService teamsService;
 
     @Autowired
     public MembershipsServiceImpl(
             MembershipRepository membershipRepository,
-            RoleRepository roleRepository,
+            RolesService rolesService,
             TeamsService teamsService) {
         this.membershipRepository = membershipRepository;
-        this.roleRepository = roleRepository;
+        this.rolesService = rolesService;
         this.teamsService = teamsService;
     }
 
@@ -46,8 +46,7 @@ public class MembershipsServiceImpl implements MembershipsService {
         UUID roleId = ofNullable(m.getRole()).map(Role::getId)
                 .orElseThrow(() -> new InvalidArgumentException(Role.class));
 
-        roleRepository.findById(roleId)
-                .orElseThrow(() -> new ResourceNotFoundException(Role.class, roleId));
+        rolesService.getRole(roleId);
 
         UUID userId = ofNullable(m.getUserId())
                 .orElseThrow(() -> new InvalidArgumentException(User.class));

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -3,9 +3,7 @@ package com.ecore.roles.service.impl;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.exception.ResourceNotFoundException;
 import com.ecore.roles.model.Role;
-import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
-import com.ecore.roles.service.MembershipsService;
 import com.ecore.roles.service.RolesService;
 import lombok.NonNull;
 import lombok.extern.log4j.Log4j2;
@@ -22,17 +20,11 @@ public class RolesServiceImpl implements RolesService {
     public static final String DEFAULT_ROLE = "Developer";
 
     private final RoleRepository roleRepository;
-    private final MembershipRepository membershipRepository;
-    private final MembershipsService membershipsService;
 
     @Autowired
     public RolesServiceImpl(
-            RoleRepository roleRepository,
-            MembershipRepository membershipRepository,
-            MembershipsService membershipsService) {
+            RoleRepository roleRepository) {
         this.roleRepository = roleRepository;
-        this.membershipRepository = membershipRepository;
-        this.membershipsService = membershipsService;
     }
 
     @Override

--- a/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/MembershipsServiceTest.java
@@ -4,7 +4,6 @@ import com.ecore.roles.exception.InvalidArgumentException;
 import com.ecore.roles.exception.ResourceExistsException;
 import com.ecore.roles.model.Membership;
 import com.ecore.roles.repository.MembershipRepository;
-import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.impl.MembershipsServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +33,7 @@ class MembershipsServiceTest {
     @Mock
     private MembershipRepository membershipRepository;
     @Mock
-    private RoleRepository roleRepository;
+    private RolesService rolesService;
     @Mock
     private UsersService usersService;
     @Mock
@@ -43,8 +42,8 @@ class MembershipsServiceTest {
     @Test
     void shouldCreateMembership() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+        when(rolesService.getRole(expectedMembership.getRole().getId()))
+                .thenReturn(DEVELOPER_ROLE());
         when(teamsService.getTeam(expectedMembership.getTeamId()))
                 .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
         when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
@@ -58,7 +57,7 @@ class MembershipsServiceTest {
 
         assertNotNull(actualMembership);
         assertEquals(actualMembership, expectedMembership);
-        verify(roleRepository).findById(expectedMembership.getRole().getId());
+        verify(rolesService).getRole(expectedMembership.getRole().getId());
     }
 
     @Test
@@ -70,8 +69,8 @@ class MembershipsServiceTest {
     @Test
     void shouldFailToCreateMembershipWhenItExists() {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+        when(rolesService.getRole(expectedMembership.getRole().getId()))
+                .thenReturn(DEVELOPER_ROLE());
         when(teamsService.getTeam(expectedMembership.getTeamId()))
                 .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
         when(membershipRepository.findByUserIdAndTeamId(expectedMembership.getUserId(),
@@ -83,7 +82,7 @@ class MembershipsServiceTest {
 
         assertEquals("Membership already exists", exception.getMessage());
         verify(teamsService, times(1)).getTeam(any());
-        verify(roleRepository, times(0)).getById(any());
+        verify(rolesService, times(1)).getRole(any());
         verify(usersService, times(0)).getUser(any());
     }
 
@@ -97,7 +96,7 @@ class MembershipsServiceTest {
 
         assertEquals("Invalid 'Role' object", exception.getMessage());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
-        verify(roleRepository, times(0)).getById(any());
+        verify(rolesService, times(0)).getRole(any());
         verify(usersService, times(0)).getUser(any());
         verify(teamsService, times(0)).getTeam(any());
     }
@@ -107,15 +106,15 @@ class MembershipsServiceTest {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         expectedMembership.setTeamId(null);
 
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+        when(rolesService.getRole(expectedMembership.getRole().getId()))
+                .thenReturn(DEVELOPER_ROLE());
 
         InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
                 () -> membershipsService.createMembership(expectedMembership));
 
         assertEquals("Invalid 'Team' object", exception.getMessage());
+        verify(rolesService, times(1)).getRole(any());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
-        verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
         verify(teamsService, times(0)).getTeam(any());
     }
@@ -125,15 +124,15 @@ class MembershipsServiceTest {
         Membership expectedMembership = DEFAULT_MEMBERSHIP();
         expectedMembership.setUserId(null);
 
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+        when(rolesService.getRole(expectedMembership.getRole().getId()))
+                .thenReturn(DEVELOPER_ROLE());
 
         InvalidArgumentException exception = assertThrows(InvalidArgumentException.class,
                 () -> membershipsService.createMembership(expectedMembership));
 
         assertEquals("Invalid 'User' object", exception.getMessage());
+        verify(rolesService, times(1)).getRole(any());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
-        verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
         verify(teamsService, times(0)).getTeam(any());
     }
@@ -142,8 +141,8 @@ class MembershipsServiceTest {
     void shouldFailToCreateMembershipWhenUserDoesNotBelongToTeam() {
         Membership expectedMembership = INVALID_MEMBERSHIP();
 
-        when(roleRepository.findById(expectedMembership.getRole().getId()))
-                .thenReturn(Optional.ofNullable(DEVELOPER_ROLE()));
+        when(rolesService.getRole(expectedMembership.getRole().getId()))
+                .thenReturn(DEVELOPER_ROLE());
 
         when(teamsService.getTeam(expectedMembership.getTeamId()))
                 .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
@@ -153,8 +152,8 @@ class MembershipsServiceTest {
 
         assertEquals("Invalid 'Membership' object. The provided user doesn't belong to the provided team.",
                 exception.getMessage());
+        verify(rolesService, times(1)).getRole(any());
         verify(membershipRepository, times(0)).findByUserIdAndTeamId(any(), any());
-        verify(roleRepository, times(0)).getById(any());
         verify(usersService, times(0)).getUser(any());
     }
 


### PR DESCRIPTION
## Description
The implementation of the RolesService and MembershipService were highly coupled and even had circular dependencies

## Proposed Changes
* Remove the dependencies to MembershipServiceImpl from RolesServiceImpl
* In the MembershipServiceImpl we replaced the dependency with the RolesRepository to use the RolesService directly.
  This will enable us to easily replace the implementation of the RolesService once we want to separate both modules.
* Fix all the tests accordingly