### PR TITLE
ECO-010 Implement get role by user id and team id in RolesServiceImpl

### DIFF
--- a/src/main/java/com/ecore/roles/client/model/Team.java
+++ b/src/main/java/com/ecore/roles/client/model/Team.java
@@ -32,4 +32,12 @@ public class Team {
 
     @JsonProperty
     private List<UUID> teamMemberIds;
+
+    public boolean userBelongsToTeam(UUID userId) {
+
+        boolean userIsTeamLead = userId.equals(this.teamLeadId);
+        boolean userBelongsToMembers = this.teamMemberIds.contains(userId);
+
+        return userIsTeamLead || userBelongsToMembers;
+    }
 }

--- a/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/ecore/roles/exception/ResourceNotFoundException.java
@@ -9,4 +9,8 @@ public class ResourceNotFoundException extends RuntimeException {
     public <T> ResourceNotFoundException(Class<T> resource, UUID id) {
         super(format("%s %s not found", resource.getSimpleName(), id));
     }
+
+    public <T> ResourceNotFoundException(Class<T> resource, String message) {
+        super(format("Resource %s not found. %s", resource.getSimpleName(), message));
+    }
 }

--- a/src/main/java/com/ecore/roles/service/MembershipsService.java
+++ b/src/main/java/com/ecore/roles/service/MembershipsService.java
@@ -10,5 +10,8 @@ public interface MembershipsService {
 
     Membership createMembership(Membership membership) throws ResourceNotFoundException;
 
+    Membership getMemberships(UUID teamId, UUID userId);
+
     List<Membership> getMemberships(UUID roleId);
 }
+

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -57,7 +57,7 @@ public class MembershipsServiceImpl implements MembershipsService {
         Team team = ofNullable(teamsService.getTeam(teamId))
                 .orElseThrow(() -> new ResourceNotFoundException(Team.class, teamId));
 
-        if (!userBelongsToTeam(userId, team)) {
+        if (!team.userBelongsToTeam(userId)) {
             throw new InvalidArgumentException(Membership.class,
                     "The provided user doesn't belong to the provided team.");
         }
@@ -70,19 +70,13 @@ public class MembershipsServiceImpl implements MembershipsService {
         return membershipRepository.save(m);
     }
 
-    private boolean userBelongsToTeam(UUID userId, Team team) {
-
-        boolean userIsTeamLead = userId.equals(team.getTeamLeadId());
-
-        boolean userBelongsToMembers = team.getTeamMemberIds()
-                .stream()
-                .anyMatch(userId::equals);
-
-        return userIsTeamLead || userBelongsToMembers;
-    }
-
     @Override
     public List<Membership> getMemberships(@NonNull UUID rid) {
         return membershipRepository.findByRoleId(rid);
+    }
+
+    @Override
+    public Membership getMemberships(UUID teamId, UUID userId) {
+        return null;
     }
 }

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -1,10 +1,10 @@
 package com.ecore.roles.service;
 
 import com.ecore.roles.exception.ResourceNotFoundException;
-import com.ecore.roles.service.model.Role;
-import com.ecore.roles.repository.MembershipRepository;
 import com.ecore.roles.repository.RoleRepository;
 import com.ecore.roles.service.impl.RolesServiceImpl;
+import com.ecore.roles.service.model.Membership;
+import com.ecore.roles.service.model.Role;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,12 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
 
-import static com.ecore.roles.utils.TestData.DEVELOPER_ROLE;
-import static com.ecore.roles.utils.TestData.UUID_1;
+import static com.ecore.roles.utils.TestData.*;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,13 +33,13 @@ class RolesServiceTest {
     private RoleRepository roleRepository;
 
     @Mock
-    private MembershipRepository membershipRepository;
-
-    @Mock
     private MembershipsService membershipsService;
 
+    @Mock
+    private TeamsService teamsService;
+
     @Test
-    public void shouldCreateRole() {
+    void shouldCreateRole() {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.save(developerRole)).thenReturn(developerRole);
 
@@ -48,13 +50,13 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToCreateRoleWhenRoleIsNull() {
+    void shouldFailToCreateRoleWhenRoleIsNull() {
         assertThrows(NullPointerException.class,
                 () -> rolesService.createRole(null));
     }
 
     @Test
-    public void shouldReturnRoleWhenRoleIdExists() {
+    void shouldReturnRoleWhenRoleIdExists() {
         Role developerRole = DEVELOPER_ROLE();
         when(roleRepository.findById(developerRole.getId())).thenReturn(Optional.of(developerRole));
 
@@ -65,10 +67,64 @@ class RolesServiceTest {
     }
 
     @Test
-    public void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
+    void shouldFailToGetRoleWhenRoleIdDoesNotExist() {
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> rolesService.getRole(UUID_1));
 
         assertEquals(format("Role %s not found", UUID_1), exception.getMessage());
+    }
+
+    @Test
+    void shouldReturnRoleByTeamIdAndUserId() {
+        Role expectedRole = DEVELOPER_ROLE();
+        Membership defaultMembership = DEFAULT_MEMBERSHIP();
+
+        when(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+                .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
+        when(membershipsService.getMemberships(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
+                .thenReturn(defaultMembership);
+        when(roleRepository.findById(defaultMembership.getRole().getId()))
+                .thenReturn(Optional.of(expectedRole));
+
+        Role role = rolesService.getRole(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID);
+
+        assertNotNull(role);
+        assertEquals(expectedRole, role);
+    }
+
+    @Test
+    void shouldFailToGetRoleByTeamIdAndUserIdIfTheTeamDoesNotExists() {
+        when(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+                .thenReturn(null);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> rolesService.getRole(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID));
+
+        assertEquals(format("Team %s not found", ORDINARY_CORAL_LYNX_TEAM_UUID),
+                exception.getMessage());
+
+        verify(teamsService, times(1)).getTeam(any());
+        verify(membershipsService, times(0)).getMemberships(any(), any());
+        verify(roleRepository, times(0)).findAllById(any());
+    }
+
+    @Test
+    void shouldFailToGetRoleByTeamIdAndUserIdIfTheMembershipDoesNotExists() {
+        when(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
+                .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
+        when(membershipsService.getMemberships(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
+                .thenReturn(null);
+
+        ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
+                () -> rolesService.getRole(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID));
+
+        assertEquals("Resource Role not found. Invalid userId (fd282131-d8aa-4819-b0c8-d9e0bfb1b75c) " +
+                        "and teamId (7676a4bf-adfe-415c-941b-1739af07039b) combination.",
+                exception.getMessage());
+
+        verify(teamsService, times(1)).getTeam(any());
+        verify(membershipsService, times(1)).getMemberships(any(), any());
+        verify(roleRepository, times(0)).findAllById(any());
+
     }
 }

--- a/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
+++ b/src/test/java/com/ecore/roles/utils/RestAssuredHelper.java
@@ -54,10 +54,10 @@ public class RestAssuredHelper {
 
     public static EcoreValidatableResponse getRole(UUID userId, UUID teamId) {
         return sendRequest(given()
-                .queryParam("teamMemberId", userId)
-                .queryParam("teamId", teamId)
+                .pathParam("teamId", teamId)
+                .pathParam("userId", userId)
                 .when()
-                .get("/v1/roles/search")
+                .get("/v1/roles/team/{teamId}/user/{userId}")
                 .then());
     }
 


### PR DESCRIPTION
## Description
In order to continue with the implementation of the new endpoint we need to implement the service layer

## Proposed Changes
* Implement logic for the service layer by verifying that the requested team exists and
  using the membershipService to retrieve the relation between user, team and role
* Add method in team model to verify is a user is part of the team
* Define a method in the membershipService to retrieve by teamId and userId
* Remove unused method and constant in RolesService
* Create new tests and update existing ones according to the above changes