### PR TITLE
ECO-011 Implement get membership by user id and team id in MembershipServiceImpl

### DIFF
--- a/src/main/java/com/ecore/roles/service/MembershipsService.java
+++ b/src/main/java/com/ecore/roles/service/MembershipsService.java
@@ -10,7 +10,7 @@ public interface MembershipsService {
 
     Membership createMembership(Membership membership) throws ResourceNotFoundException;
 
-    Membership getMemberships(UUID teamId, UUID userId);
+    Membership getMembership(UUID teamId, UUID userId);
 
     List<Membership> getMemberships(UUID roleId);
 }

--- a/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/MembershipsServiceImpl.java
@@ -76,7 +76,10 @@ public class MembershipsServiceImpl implements MembershipsService {
     }
 
     @Override
-    public Membership getMemberships(UUID teamId, UUID userId) {
-        return null;
+    public Membership getMembership(@NonNull UUID teamId, @NonNull UUID userId) {
+        return membershipRepository.findByUserIdAndTeamId(userId, teamId)
+                .orElseThrow(() -> new ResourceNotFoundException(Membership.class,
+                        String.format("Invalid userId (%s) and teamId (%s) combination.",
+                                userId, teamId)));
     }
 }

--- a/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
+++ b/src/main/java/com/ecore/roles/service/impl/RolesServiceImpl.java
@@ -60,11 +60,7 @@ public class RolesServiceImpl implements RolesService {
         Team team = ofNullable(teamsService.getTeam(teamId))
                 .orElseThrow(() -> new ResourceNotFoundException(Team.class, teamId));
 
-        Membership membership = ofNullable(membershipsService.getMemberships(team.getId(), userId))
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        Role.class,
-                        String.format("Invalid userId (%s) and teamId (%s) combination.",
-                                userId, teamId)));
+        Membership membership = membershipsService.getMembership(team.getId(), userId);
 
         return getRole(membership.getRole().getId());
     }

--- a/src/test/java/com/ecore/roles/api/RolesApiTest.java
+++ b/src/test/java/com/ecore/roles/api/RolesApiTest.java
@@ -131,29 +131,10 @@ class RolesApiTest {
     }
 
     @Test
-    void shouldFailToGetRoleByUserIdAndTeamIdWhenMissingUserId() {
-        getRole(null, ORDINARY_CORAL_LYNX_TEAM_UUID)
-                .validate(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase());
-    }
-
-    @Test
-    void shouldFailToGetRoleByUserIdAndTeamIdWhenMissingTeamId() {
-        getRole(GIANNI_USER_UUID, null)
-                .validate(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase());
-    }
-
-    @Test
     void shouldFailToGetRoleByUserIdAndTeamIdWhenItDoesNotExist() {
         mockGetTeamById(mockServer, UUID_1, null);
         getRole(GIANNI_USER_UUID, UUID_1)
                 .validate(HttpStatus.NOT_FOUND.value(), format("Team %s not found", UUID_1));
     }
 
-    @Test
-    void shouldFailToGetRoleByUserIdAndTeamIdWhenUserDoesNotBelongToTheTeam() {
-        mockGetTeamById(mockServer, UUID_1, null);
-        getRole(GIANNI_USER_UUID, UUID_1)
-                .validate(HttpStatus.BAD_REQUEST.value(),
-                        "Invalid 'Membership' object. The provided user doesn't belong to the provided team.");
-    }
 }

--- a/src/test/java/com/ecore/roles/service/RolesServiceTest.java
+++ b/src/test/java/com/ecore/roles/service/RolesServiceTest.java
@@ -81,7 +81,7 @@ class RolesServiceTest {
 
         when(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
                 .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
-        when(membershipsService.getMemberships(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
+        when(membershipsService.getMembership(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
                 .thenReturn(defaultMembership);
         when(roleRepository.findById(defaultMembership.getRole().getId()))
                 .thenReturn(Optional.of(expectedRole));
@@ -104,7 +104,7 @@ class RolesServiceTest {
                 exception.getMessage());
 
         verify(teamsService, times(1)).getTeam(any());
-        verify(membershipsService, times(0)).getMemberships(any(), any());
+        verify(membershipsService, times(0)).getMembership(any(), any());
         verify(roleRepository, times(0)).findAllById(any());
     }
 
@@ -112,18 +112,16 @@ class RolesServiceTest {
     void shouldFailToGetRoleByTeamIdAndUserIdIfTheMembershipDoesNotExists() {
         when(teamsService.getTeam(ORDINARY_CORAL_LYNX_TEAM_UUID))
                 .thenReturn(ORDINARY_CORAL_LYNX_TEAM(true));
-        when(membershipsService.getMemberships(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
-                .thenReturn(null);
+        when(membershipsService.getMembership(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID))
+                .thenThrow(new ResourceNotFoundException(Membership.class, "Test error message"));
 
         ResourceNotFoundException exception = assertThrows(ResourceNotFoundException.class,
                 () -> rolesService.getRole(ORDINARY_CORAL_LYNX_TEAM_UUID, GIANNI_USER_UUID));
 
-        assertEquals("Resource Role not found. Invalid userId (fd282131-d8aa-4819-b0c8-d9e0bfb1b75c) " +
-                        "and teamId (7676a4bf-adfe-415c-941b-1739af07039b) combination.",
-                exception.getMessage());
+        assertEquals("Resource Membership not found. Test error message", exception.getMessage());
 
         verify(teamsService, times(1)).getTeam(any());
-        verify(membershipsService, times(1)).getMemberships(any(), any());
+        verify(membershipsService, times(1)).getMembership(any(), any());
         verify(roleRepository, times(0)).findAllById(any());
 
     }


### PR DESCRIPTION
## Description
We want to implement in the membershipService a method to get the membership by userId and teamId

## Proposed Changes
* Implement the logic to retrieve from the database the membership by userId and teamId
* Handle resource not found exception in this service instead of the RolesService
* Update tests accordingly and remove old API tests since the endpoint is using now path variables